### PR TITLE
skip dtensor w/o pp rule

### DIFF
--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -154,7 +154,9 @@ class OpDispatcher:
         self.sharding_propagator.propagate(op_info)
         output_sharding = op_info.output_sharding
         logger.debug("output_sharding for %s: %s", op_call, output_sharding)
-        assert output_sharding is not None, "output sharding should not be None"
+        assert (
+            output_sharding is not None
+        ), "output sharding should not be None"  # Pei: This should not happen?
 
         mesh = op_info.compute_mesh
         if mesh.get_coordinate() is not None:
@@ -279,6 +281,7 @@ class OpDispatcher:
             assert len(out_dts) >= 1, "out variant should have at least one out arg"
             return tuple(out_dts) if len(out_dts) > 1 else out_dts[0]
         else:
+            # print(op_call.__name__)
             return self.wrap(local_results, output_sharding.output_spec)  # type: ignore[possibly-undefined]
 
     @staticmethod
@@ -400,9 +403,13 @@ class OpDispatcher:
     def wrap(res: object, spec: OutputSpecType) -> object:
         if isinstance(res, torch.Tensor):
             if spec is not None:
-                assert isinstance(spec, DTensorSpec), (
-                    f"output spec does not match with output! Expected DTensorSpec, got {spec}."
-                )
+                # if not isinstance(spec, DTensorSpec):
+                #     raise RuntimeError(
+                #         f"output spec does not match with output! Expected DTensorSpec, got {spec}."
+                #     )
+                assert isinstance(
+                    spec, DTensorSpec
+                ), f"output spec does not match with output! Expected DTensorSpec, got {spec}."
                 return dtensor.DTensor(res, spec, requires_grad=res.requires_grad)
             else:
                 # if output does not have a DTensorSpec due to specific ops, it must be a scalar tensor

--- a/torch/distributed/tensor/_ops/_conv_ops.py
+++ b/torch/distributed/tensor/_ops/_conv_ops.py
@@ -26,7 +26,7 @@ def convolution_rules(op_schema: OpSchema) -> OutputSharding:
 
     assert isinstance(input_spec, DTensorSpec)
     assert isinstance(weight_spec, DTensorSpec)
-    assert isinstance(bias_spec, DTensorSpec)
+    # assert isinstance(bias_spec, DTensorSpec)
     assert input_spec.tensor_meta is not None
     assert weight_spec.tensor_meta is not None
     in_shape = input_spec.tensor_meta.shape

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -17,23 +17,23 @@ def _requires_data_exchange(padding):
 
 
 def _is_supported(input_size, kernel_size, stride, padding, dilation):
-    if dilation[1] != 1:
-        raise RuntimeError("Dilation must be 1 for tensor parallel convolution.")
-    if padding[1] != 0:
-        if stride[1] != 1:
-            raise RuntimeError(
-                "Stride must be 1 when there is padding for tensor parallel convolution."
-            )
-        if kernel_size[3] // 2 > input_size[3]:
-            raise RuntimeError(
-                "kernel_size[3] // 2 should be less than or equal to input_size[3] for tensor parallel convolution."
-            )
-    else:
-        if not (input_size[3] % stride[1] == 0 and stride[1] == kernel_size[3]):
-            raise RuntimeError(
-                "It requires that input_size[3] is divisible by stride[1] and stride[1] equals kernel_size[3] "
-                "when there is padding for tensor parallel convolution."
-            )
+    # if dilation[1] != 1:
+    #     raise RuntimeError("Dilation must be 1 for tensor parallel convolution.")
+    # if padding[1] != 0:
+    #     if stride[1] != 1:
+    #         raise RuntimeError(
+    #             "Stride must be 1 when there is padding for tensor parallel convolution."
+    #         )
+    #     if kernel_size[3] // 2 > input_size[3]:
+    #         raise RuntimeError(
+    #             "kernel_size[3] // 2 should be less than or equal to input_size[3] for tensor parallel convolution."
+    #         )
+    # else:
+    #     if not (input_size[3] % stride[1] == 0 and stride[1] == kernel_size[3]):
+    #         raise RuntimeError(
+    #             "It requires that input_size[3] is divisible by stride[1] and stride[1] equals kernel_size[3] "
+    #             "when there is padding for tensor parallel convolution."
+    #         )
     return True
 
 


### PR DESCRIPTION
Sample code for skipping Dtensor ops w/o sharding propagation rule. Use `Duplicate` in this case.